### PR TITLE
Add Romania and Abarai to Europe exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -286,6 +286,17 @@ id: exchanges
           </p>
         </div>
       </div>
+      
+      <div class="row marketplace">
+        <img class="marketplace-flag" src="/img/flags/RO.svg?{{site.time | date: '%s'}}" alt="Romanian flag">
+        <div>
+          <h3 id="romania" class="no_toc">Romania</h3>
+          <p>
+          <a class="marketplace-link" href="https://abarai.ro">Abarai</a>
+        </p>
+      </div>
+    </div>
+
 
       <div class="row marketplace">
         <img class="marketplace-flag" src="/img/flags/UA.svg?{{site.time | date: '%s'}}" alt="Ukrainian flag">


### PR DESCRIPTION
This PR adds Romania under the Europe section of exchanges and lists Abarai (https://abarai.ro).
- Uses existing HTML structure and style
- RO.svg flag already present in /img/flags
- Maintains alphabetical order between Poland and Ukraine
